### PR TITLE
Fix overflow

### DIFF
--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -30,7 +30,6 @@ export default {
 </script>
 <style lang="scss" scoped>
 #about {
-	height: 100vh;
 	width: 100%;
 	display: flex;
 	flex-direction: column;

--- a/static/node_modules/propdoc/style.scss
+++ b/static/node_modules/propdoc/style.scss
@@ -80,6 +80,13 @@ pre code {
 .use, .props {
 	margin: 2.8rem 0;
 }
+
+.token, .props{
+	padding-bottom: 15px;
+	width: 100%;
+	overflow-x: auto;
+}
+
 .token pre {
 	margin: 0;
 }


### PR DESCRIPTION
Overflow issue on guide page fix.

Add 3 CSS properties in token and props class in '@/../static/node_modules/style.scss'. This fix the issue.
Fixes #71 #73