### PR TITLE
provide different keys for icons used in testimonials.

### DIFF
--- a/src/components/Testimonial.vue
+++ b/src/components/Testimonial.vue
@@ -2,8 +2,8 @@
 	<b-card-group class="testimonialContainer">
 		<b-card v-for="testimonial in testimonials" class="testimonial" :key="testimonial.id">
 			<div id="hearts">
-				<i class="material-icons" v-for="n in testimonial.stars" :key="n" style="text-align: center; color: #dc3545;">favorite</i>
-				<i class="material-icons" v-for="n in 5 - testimonial.stars" :key="n" style="text-align: center; color: #dc3545;">favorite_border</i>
+				<i class="material-icons" v-for="n in testimonial.stars" :key="n + '-a'" style="text-align: center; color: #dc3545;">favorite</i>
+				<i class="material-icons" v-for="n in 5 - testimonial.stars" :key="n + '-b'" style="text-align: center; color: #dc3545;">favorite_border</i>
 			</div>
             <blockquote class="blockquote mb-0">
                 <p style="font-size: 16px">{{ testimonial.testimonial }}</p>


### PR DESCRIPTION
The icons rendered in Testimonial component had same value for key being in the same level. Suffixes have been added to make the keys distinguishable.

The changes have been made in compliance with this discussion [vuejs#7323](https://github.com/vuejs/vue/issues/7323)

fixes #93